### PR TITLE
Multiple hard drivers running windows.

### DIFF
--- a/src/java/com/beaconhill/s3cp/AWSKeys.java
+++ b/src/java/com/beaconhill/s3cp/AWSKeys.java
@@ -57,10 +57,14 @@ public class AWSKeys {
 
 	public void loadFromSystem(String accountName) {
 		String propFile = System.getenv().get("HOME");
-		
+
 		// The name of Windows' env for the home directory is a little different.
 		if (propFile == null) {
-			propFile = System.getenv().get("HOMEPATH");
+      String propDrive = System.getenv().get("HOMEDRIVE");
+			propFile  = System.getenv().get("HOMEPATH");
+
+      if (propDrive != null && (propFile.charAt(0) == '\\' || propFile.charAt(0) == '/'))
+        propFile = propDrive + propFile;
 		}
 		
 		propFile += "/.s3cp/s3cp.properties";


### PR DESCRIPTION
Hi Brad,

It's me again. I had yet another issue with a windows machine that makes use of multiple drive letters.
The home directory look up would fail if the context drive wouldn't happen to be the one that stores the home folder. It's a minor change that should be easy to merge.

Thanks,
Sebastian
